### PR TITLE
BUGFIX: Add allowed_actions to RegistryImportFeed_Controller

### DIFF
--- a/code/RegistryImportFeed.php
+++ b/code/RegistryImportFeed.php
@@ -67,6 +67,10 @@ class RegistryImportFeed_Entry extends ViewableData {
 }
 class RegistryImportFeed_Controller extends Controller {
 
+	private static $allowed_actions = array(
+		'latest'
+	);
+
 	public static $url_handlers = array(
 		'$Action/$ModelClass' => 'handleAction',
 	);


### PR DESCRIPTION
This fixes CWPBUG-111, and allows you to use the latest controller method (e.g. http://localhost/registry-feed/latest/StaffMember) to give you an RSS feed of latest StaffMember objects.
