### PR TITLE
BUGFIX: Remove `TestOnly` interface to allow LeftAndMainTest to pass.

### DIFF
--- a/tests/model/RegistryPageTestContact.php
+++ b/tests/model/RegistryPageTestContact.php
@@ -1,5 +1,5 @@
 <?php
-class RegistryPageTestContact extends DataObject implements RegistryDataInterface, TestOnly {
+class RegistryPageTestContact extends DataObject implements RegistryDataInterface {
 
 	private static $db = array(
 		'FirstName' => 'Varchar(50)',


### PR DESCRIPTION
Normally, you could add the 'TestOnly' class, and then add that class into 
your main Test's `$extraDataObjects` var to have it loaded only during tests. 
However, we can't do that here, because LeftAndMain is where we would need to 
add it, and we can't modify core. Instead, we remove the `TestOnly` interface. 
The database isn't built with this class because it lives in the tests/ 
folder, so there's no risk that this leaks the class into the normal database.
