### PR TITLE
FIX Add table_name config to help upgrading go smoothly

### DIFF
--- a/src/RegistryPage.php
+++ b/src/RegistryPage.php
@@ -18,6 +18,8 @@ class RegistryPage extends Page
 {
     private static $description = 'Shows large series of data in a filterable, searchable, and paginated list';
 
+    private static $table_name = 'RegistryPage';
+
     private static $db = [
         'DataClass' => 'Varchar(100)',
         'PageLength' => 'Int',


### PR DESCRIPTION
This will ensure that upgrading from SS3 to SS4 will not change the database table name, which reduces the amount of work a dev needs to do when upgrading their project.