### PR TITLE
FIX Santise class names for URLs and folder names and exclude irrelevant classes from feed

### DIFF
--- a/src/RegistryImportFeed.php
+++ b/src/RegistryImportFeed.php
@@ -23,20 +23,20 @@ class RegistryImportFeed
     {
         $files = ArrayList::create();
 
-        $path = REGISTRY_IMPORT_PATH . '/' . $this->modelClass;
+        $path = REGISTRY_IMPORT_PATH . '/' . $this->sanitiseClassName($this->modelClass);
         if (file_exists($path)) {
             $registryPage = DataObject::get_one(
                 RegistryPage::class,
-                sprintf('"DataClass" = \'%s\'', $this->modelClass)
+                ['DataClass' => $this->modelClass]
             );
 
-            if (($registryPage && $registryPage->exists())) {
+            if ($registryPage && $registryPage->exists()) {
                 foreach (array_diff(scandir($path), array('.', '..')) as $file) {
                     $files->push(RegistryImportFeedEntry::create(
                         $file,
                         '',
                         filemtime($path . '/' . $file),
-                        REGISTRY_IMPORT_URL . '/' . $this->modelClass . '/' . $file
+                        REGISTRY_IMPORT_URL . '/' . $this->sanitiseClassName($this->modelClass) . '/' . $file
                     ));
                 }
             }
@@ -44,8 +44,19 @@ class RegistryImportFeed
 
         return RSSFeed::create(
             $files,
-            'registry-feed/latest/' . $this->modelClass,
+            'registry-feed/latest/' . $this->sanitiseClassName($this->modelClass),
             singleton($this->modelClass)->singular_name() . ' data import history'
         );
+    }
+
+    /**
+     * See {@link \SilverStripe\Admin\ModelAdmin::sanitiseClassName}
+     *
+     * @param  string $class
+     * @return string
+     */
+    protected function sanitiseClassName($class)
+    {
+        return str_replace('\\', '-', $class);
     }
 }

--- a/src/RegistryPageController.php
+++ b/src/RegistryPageController.php
@@ -449,4 +449,14 @@ class RegistryPageController extends PageController
 
         return array_merge(array_slice($templates, 0, $index), $actionlessTemplates, array_slice($templates, $index));
     }
+
+    /**
+     * Sanitise a PHP class name for display in URLs etc
+     *
+     * @return string
+     */
+    public function getClassNameForUrl($className)
+    {
+        return str_replace('\\', '-', $className);
+    }
 }

--- a/templates/SilverStripe/Registry/Layout/RegistryPage.ss
+++ b/templates/SilverStripe/Registry/Layout/RegistryPage.ss
@@ -4,7 +4,7 @@ $Content
 	$RegistryFilterForm
 </div>
 
-<a class="historyFeedLink" href="registry-feed/latest/{$DataClass}" title="<%t SilverStripe\\Registry\\RegistryPage.ViewHistory "View imported data history" %>">
+<a class="historyFeedLink" href="registry-feed/latest/{$getClassNameForUrl($DataClass)}" title="<%t SilverStripe\\Registry\\RegistryPage.ViewHistory "View imported data history" %>">
 	<%t SilverStripe\\Registry\\RegistryPage.ViewHistory "View imported data history" %>
 </a>
 

--- a/tests/RegistryImportFeedControllerTest.php
+++ b/tests/RegistryImportFeedControllerTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace SilverStripe\Registry\Tests;
+
+use SilverStripe\Dev\FunctionalTest;
+use SilverStripe\Registry\Tests\Stub\RegistryPageTestContact;
+
+class RegistryImportFeedControllerTest extends FunctionalTest
+{
+    protected static $fixture_file = 'fixtures/RegistryPageTestContact.yml';
+
+    protected static $extra_dataobjects = [
+        RegistryPageTestContact::class,
+    ];
+
+    public function testNonExistentClassInLatestFeedReturnsNotFound()
+    {
+        $result = $this->get('registry-feed/latest/Non-Existent-Class-Name-Here-Monkey');
+
+        $this->assertEquals(404, $result->getStatusCode());
+    }
+
+    public function testClassNotImplementingRegistryInterfaceReturnsNotFound()
+    {
+        $result = $this->get('registry-feed/latest/Page');
+
+        $this->assertEquals(404, $result->getStatusCode());
+    }
+
+    public function testValidRegistryClassReturnsXmlFeed()
+    {
+        $result = $this->get('registry-feed/latest/SilverStripe-Registry-Tests-Stub-RegistryPageTestContact');
+
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+}


### PR DESCRIPTION
Fixes #34 

This PR converts backslashes to dashes where class names are used in URLs and filesystem paths, as well as excluding non-existent classes and classes that don't implement `RegistryDataInterface` from the version feed, since they would just render an error in the former case and an empty feed in the latter case.