### PR TITLE
Add exact filters for relationships

### DIFF
--- a/tests/RegistryPageFunctionalTest.php
+++ b/tests/RegistryPageFunctionalTest.php
@@ -93,7 +93,7 @@ class RegistryPageFunctionalTest extends FunctionalTest
         $uri = Controller::join_links(
             $page->RelativeLink('RegistryFilterForm'),
             '?' . http_build_query(array(
-                'RegistryPage.ID' => 2,
+                'RegistryPage.ID' => $page->ID,
                 'action_doRegistryFilter' => 'Filter',
             ))
         );
@@ -106,6 +106,9 @@ class RegistryPageFunctionalTest extends FunctionalTest
         $parser = new CSSContentParser($response->getBody());
 
         $rows = $parser->getBySelector('table.results tbody tr');
+
+        // there should only be one user with that ID from our YML
+        $this->assertCount(1, $rows);
         $cells = $rows[0]->td;
 
         $this->assertCount(1, $rows);

--- a/tests/RegistryPageFunctionalTest.php
+++ b/tests/RegistryPageFunctionalTest.php
@@ -33,7 +33,7 @@ class RegistryPageFunctionalTest extends FunctionalTest
 
         $cells = $parser->getBySelector('table.results tbody tr td');
 
-        $this->assertContains('/contact-search-extra/', (string) $cells[0]->a->attributes()->href[0]);
+        $this->assertContains('/contact-search-extra/', (string)$cells[0]->a->attributes()->href[0]);
     }
 
     public function testFilteredSearchResults()
@@ -55,8 +55,8 @@ class RegistryPageFunctionalTest extends FunctionalTest
         $cells = $rows[0]->td;
 
         $this->assertCount(1, $rows);
-        $this->assertEquals('Alexander', (string) $cells[0]);
-        $this->assertEquals('Bernie', (string) $cells[1]);
+        $this->assertEquals('Alexander', trim((string)$cells[0]));
+        $this->assertEquals('Bernie', trim((string)$cells[1]));
     }
 
     public function testFilteredByRelationSearchResults()
@@ -78,8 +78,8 @@ class RegistryPageFunctionalTest extends FunctionalTest
         $cells = $rows[0]->td;
 
         $this->assertCount(1, $rows);
-        $this->assertEquals('Jimmy', (string) $cells[0]->a[0]);
-        $this->assertEquals('Sherson', (string) $cells[1]->a[0]);
+        $this->assertEquals('Jimmy', trim((string)$cells[0]->a[0]));
+        $this->assertEquals('Sherson', trim((string)$cells[1]->a[0]));
     }
 
     /**
@@ -109,8 +109,8 @@ class RegistryPageFunctionalTest extends FunctionalTest
         $cells = $rows[0]->td;
 
         $this->assertCount(1, $rows);
-        $this->assertEquals('Jimmy', (string)trim($cells[0]->a[0]));
-        $this->assertEquals('Sherson', (string)trim($cells[1]->a[0]));
+        $this->assertEquals('Jimmy', trim((string)$cells[0]->a));
+        $this->assertEquals('Sherson', trim((string)$cells[1]->a));
     }
 
     public function testUserCustomSummaryField()
@@ -121,7 +121,7 @@ class RegistryPageFunctionalTest extends FunctionalTest
 
         $cells = $parser->getBySelector('table.results tbody tr td');
 
-        $this->assertContains($page->getDataSingleton()->getStaticReference(), (string) $cells[3]->a[0]);
+        $this->assertContains($page->getDataSingleton()->getStaticReference(), trim((string)$cells[4]->a[0]));
     }
 
     public function testSearchResultsLimitAndStart()
@@ -145,12 +145,12 @@ class RegistryPageFunctionalTest extends FunctionalTest
         $this->assertCount(3, $rows, 'Limited to 3 search results');
         $this->assertCount(4, $anchors, '4 paging anchors, including next');
 
-        $this->assertContains('Sort=FirstName', (string) $anchors[0]['href']);
-        $this->assertContains('Dir=DESC', (string) $anchors[0]['href']);
+        $this->assertContains('Sort=FirstName', (string)$anchors[0]['href']);
+        $this->assertContains('Dir=DESC', (string)$anchors[0]['href']);
 
-        $this->assertContains('start=0', (string) $anchors[0]['href']);
-        $this->assertContains('start=3', (string) $anchors[1]['href']);
-        $this->assertContains('start=6', (string) $anchors[2]['href']);
+        $this->assertContains('start=0', (string)$anchors[0]['href']);
+        $this->assertContains('start=3', (string)$anchors[1]['href']);
+        $this->assertContains('start=6', (string)$anchors[2]['href']);
     }
 
     public function testGetParamsPopulatesSearchForm()
@@ -172,9 +172,9 @@ class RegistryPageFunctionalTest extends FunctionalTest
         $sortField = $parser->getBySelector('#Form_RegistryFilterForm_Sort');
         $dirField = $parser->getBySelector('#Form_RegistryFilterForm_Dir');
 
-        $this->assertEquals('Alexander', (string) $firstNameField[0]['value']);
-        $this->assertEquals('FirstName', (string) $sortField[0]['value']);
-        $this->assertEquals('DESC', (string) $dirField[0]['value']);
+        $this->assertEquals('Alexander', (string)$firstNameField[0]['value']);
+        $this->assertEquals('FirstName', (string)$sortField[0]['value']);
+        $this->assertEquals('DESC', (string)$dirField[0]['value']);
     }
 
     public function testQueryLinks()
@@ -193,11 +193,11 @@ class RegistryPageFunctionalTest extends FunctionalTest
         $rows = $parser->getBySelector('table.results thead tr');
         $anchors = $rows[0]->th->a;
 
-        $this->assertContains('FirstName=Alexander', (string) $anchors[0]['href']);
-        $this->assertContains('Surname=', (string) $anchors[0]['href']);
-        $this->assertContains('Sort=FirstName', (string) $anchors[0]['href']);
-        $this->assertContains('Dir=ASC', (string) $anchors[0]['href']);
-        $this->assertContains('action_doRegistryFilter=Filter', (string) $anchors[0]['href']);
+        $this->assertContains('FirstName=Alexander', (string)$anchors[0]['href']);
+        $this->assertContains('Surname=', (string)$anchors[0]['href']);
+        $this->assertContains('Sort=FirstName', (string)$anchors[0]['href']);
+        $this->assertContains('Dir=ASC', (string)$anchors[0]['href']);
+        $this->assertContains('action_doRegistryFilter=Filter', (string)$anchors[0]['href']);
     }
 
     public function testShowExistingRecord()
@@ -231,7 +231,7 @@ class RegistryPageFunctionalTest extends FunctionalTest
         $rows = $parser->getBySelector('table.results thead tr');
         $anchors = $rows[0]->th->a;
 
-        $this->assertEquals('First name', (string) $anchors[0]);
+        $this->assertEquals('First name', trim((string)$anchors[0]));
     }
 
     public function testSortableColumns()
@@ -244,7 +244,8 @@ class RegistryPageFunctionalTest extends FunctionalTest
         $this->assertNotEmpty($columns[0]->a);
         $this->assertNotEmpty($columns[1]->a);
         $this->assertNotEmpty($columns[2]->a);
-        $this->assertEquals('Other', $columns[3]);
+        $this->assertNotEmpty($columns[3]->a);
+        $this->assertEquals('Other', trim((string)$columns[4]));
     }
 
     public function testExportLink()
@@ -264,11 +265,11 @@ class RegistryPageFunctionalTest extends FunctionalTest
         $parser = new CSSContentParser($response->getBody());
         $anchor = $parser->getBySelector('a.export');
 
-        $this->assertContains('export?', (string) $anchor[0]['href']);
-        $this->assertContains('FirstName=Alexander', (string) $anchor[0]['href']);
-        $this->assertContains('Surname=', (string) $anchor[0]['href']);
-        $this->assertContains('Sort=FirstName', (string) $anchor[0]['href']);
-        $this->assertContains('Dir=DESC', (string) $anchor[0]['href']);
-        $this->assertContains('action_doRegistryFilter=Filter', (string) $anchor[0]['href']);
+        $this->assertContains('export?', (string)$anchor[0]['href']);
+        $this->assertContains('FirstName=Alexander', (string)$anchor[0]['href']);
+        $this->assertContains('Surname=', (string)$anchor[0]['href']);
+        $this->assertContains('Sort=FirstName', (string)$anchor[0]['href']);
+        $this->assertContains('Dir=DESC', (string)$anchor[0]['href']);
+        $this->assertContains('action_doRegistryFilter=Filter', (string)$anchor[0]['href']);
     }
 }

--- a/tests/RegistryPageFunctionalTest.php
+++ b/tests/RegistryPageFunctionalTest.php
@@ -82,6 +82,37 @@ class RegistryPageFunctionalTest extends FunctionalTest
         $this->assertEquals('Sherson', (string) $cells[1]->a[0]);
     }
 
+    /**
+     * Check that RegistryPageController can filter for ExactMatches (ID) for relationships.
+     *
+     * @throws \Exception
+     */
+    public function testFilteredByRelationIDSearchResults()
+    {
+        $page = $this->objFromFixture(RegistryPageTestPage::class, 'contact-registrypage-extra');
+        $uri = Controller::join_links(
+            $page->RelativeLink('RegistryFilterForm'),
+            '?' . http_build_query(array(
+                'RegistryPage.ID' => 2,
+                'action_doRegistryFilter' => 'Filter',
+            ))
+        );
+
+        // If this is wrong then the configuration system is broken.
+        $this->assertCount(4, $page->getDataSingleton()->config()->get('searchable_fields'));
+
+        $response = $this->get($uri);
+
+        $parser = new CSSContentParser($response->getBody());
+
+        $rows = $parser->getBySelector('table.results tbody tr');
+        $cells = $rows[0]->td;
+
+        $this->assertCount(1, $rows);
+        $this->assertEquals('Jimmy', (string)trim($cells[0]->a[0]));
+        $this->assertEquals('Sherson', (string)trim($cells[1]->a[0]));
+    }
+
     public function testUserCustomSummaryField()
     {
         $page = $this->objFromFixture(RegistryPageTestPage::class, 'contact-registrypage-extra');
@@ -104,7 +135,6 @@ class RegistryPageFunctionalTest extends FunctionalTest
                 'action_doRegistryFilter' => 'Filter'
             ))
         );
-
 
         $response = $this->get($uri);
 

--- a/tests/Stub/RegistryPageTestContactExtra.php
+++ b/tests/Stub/RegistryPageTestContactExtra.php
@@ -29,13 +29,15 @@ class RegistryPageTestContactExtra extends DataObject implements RegistryDataInt
         'FirstName' => 'First name',
         'Surname' => 'Surname',
         'RegistryPage.Title' => 'Registry Page',
+        'RegistryPage.ID' => 'Registry Page ID',
         'StaticReference' => 'Other'
     ];
 
     private static $searchable_fields = [
         'FirstName',
         'Surname',
-        'RegistryPage.Title'
+        'RegistryPage.Title',
+        'RegistryPage.ID',
     ];
 
     public function getSearchFields()
@@ -43,7 +45,8 @@ class RegistryPageTestContactExtra extends DataObject implements RegistryDataInt
         return new FieldList(
             new TextField('FirstName', 'First name'),
             new TextField('Surname', 'Surname'),
-            new TextField('RegistryPage.Title', 'Registry Page')
+            new TextField('RegistryPage.Title', 'Registry Page'),
+            new TextField('RegistryPage.ID', 'Registry ID')
         );
     }
 


### PR DESCRIPTION
Check to see if the field referenced is a relationship on the instance, if it's found, then we should do an exact match over a partial match, so part ID's aren't returned. 

@see issue #49

(WIP as i need to do tests still) 