### PR TITLE
Use summary fields for export columns

### DIFF
--- a/src/RegistryAdmin.php
+++ b/src/RegistryAdmin.php
@@ -43,10 +43,8 @@ class RegistryAdmin extends ModelAdmin
 
     public function getExportFields()
     {
-        $dataObjectSchema = DataObject::getSchema();
-
         $fields = [];
-        foreach ($dataObjectSchema->databaseFields($this->modelClass) as $field => $spec) {
+        foreach (singleton($this->modelClass)->summaryFields() as $field => $spec) {
             $fields[$field] = $field;
         }
         return $fields;


### PR DESCRIPTION
Switch to using summary fields for export. This avoids exporting fields that aren't needed or are problematic in the export, especially ID, which can cause issues in Excel. This is closer to the default behaviour, although using the field's name for the column rather than the GridField header text.