### PR TITLE
API Update import() signature

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "^3.0",
-        "silverstripe/versioned": "^1.12"
+        "silverstripe/versioned": "^2"
     },
     "autoload": {
         "psr-4": {

--- a/src/RegistryAdmin.php
+++ b/src/RegistryAdmin.php
@@ -5,6 +5,8 @@ namespace SilverStripe\Registry;
 use SilverStripe\Admin\ModelAdmin;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Forms\Form;
 
 class RegistryAdmin extends ModelAdmin
 {
@@ -62,12 +64,12 @@ class RegistryAdmin extends ModelAdmin
         return sprintf('%s/%s', $feed->getStoragePath($this->modelClass), $feed->getImportFilename());
     }
 
-    public function import($data, $form, $request)
+    public function import(array $data, Form $form): HTTPResponse
     {
         if (!$this->showImportForm
             || (is_array($this->showImportForm) && !in_array($this->modelClass, $this->showImportForm ?? []))
         ) {
-            return false;
+            return $this->redirectBack();
         }
 
         $importers = $this->getModelImporters();
@@ -80,8 +82,7 @@ class RegistryAdmin extends ModelAdmin
                 _t('SilverStripe\\Admin\\ModelAdmin.NOCSVFILE', 'Please browse for a CSV file to import'),
                 'bad'
             );
-            $this->redirectBack();
-            return false;
+            return $this->redirectBack();
         }
 
         if (!empty($data['EmptyBeforeImport']) && $data['EmptyBeforeImport']) { //clear database before import


### PR DESCRIPTION
Fixes 
`    - silverstripe/cms[5.0.0-alpha1, ..., 5.x-dev] require silverstripe/versioned ^2 -> found silverstripe/versioned[2.0.0-alpha1, 2.x-dev] but it conflicts with your root composer.json require (^1.12).`

https://github.com/silverstripe/silverstripe-registry/actions/runs/3645000481/jobs/6154760365#step:9:277

Also updates RegistryAdmin::import() to be compatible with the updated signature on ModelAdmin::import()

Note: not fixing the `->addPlugin()` CI failure - have raised a [new issue](https://github.com/silverstripe/silverstripe-registry/issues/75) for since it's not obvious what the fix here is since we may have lost functionality as part of the flysystem upgrade

## Parent issue
- https://github.com/silverstripeltd/product-issues/issues/642