### PR TITLE
FIX Implement support new league/flysystem v3

### DIFF
--- a/src/RegistryImportFeed.php
+++ b/src/RegistryImportFeed.php
@@ -2,13 +2,11 @@
 
 namespace SilverStripe\Registry;
 
-use League\Flysystem\Plugin\ListFiles;
 use SilverStripe\Assets\Storage\GeneratedAssetHandler;
 use SilverStripe\Control\RSS\RSSFeed;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\ORM\ArrayList;
-use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBDatetime;
 
 class RegistryImportFeed
@@ -80,8 +78,6 @@ class RegistryImportFeed
      */
     public function setAssetHandler(GeneratedAssetHandler $handler)
     {
-        $handler->getFilesystem()->addPlugin(new ListFiles);
-
         $this->assetHandler = $handler;
 
         return $this;
@@ -117,16 +113,16 @@ class RegistryImportFeed
     public function getImportFiles()
     {
         $path = $this->getStoragePath();
-        $importFiles = $this->getAssetHandler()->getFilesystem()->listFiles($path);
+        $importFiles = $this->getAssetHandler()->getFilesystem()->listContents($path)->toArray();
 
         $files = ArrayList::create();
 
         foreach ($importFiles as $importFile) {
             $files->push(RegistryImportFeedEntry::create(
-                $importFile['basename'],
+                basename($importFile->path()),
                 '',
-                DBDatetime::create()->setValue($importFile['timestamp'])->Format(DBDatetime::ISO_DATETIME),
-                $this->getAssetsDir() . '/' . $importFile['path']
+                DBDatetime::create()->setValue($importFile->lastModified())->Format(DBDatetime::ISO_DATETIME),
+                $this->getAssetsDir() . '/' . $importFile->path()
             ));
         }
 

--- a/tests/RegistryImportFeedTest.php
+++ b/tests/RegistryImportFeedTest.php
@@ -21,4 +21,26 @@ class RegistryImportFeedTest extends SapphireTest
         $importFeed = RegistryImportFeed::create();
         $this->assertStringContainsString('import-2017-01-01', $importFeed->getImportFilename());
     }
+
+    public function testGetImportFiles()
+    {
+        $importFeed = RegistryImportFeed::create();
+        $importFeed->getAssetHandler()
+            ->setContent(
+                $importFeed->getStoragePath() . "import-2023-01-01.csv",
+                'File contents'
+            );
+        $importFeed->getAssetHandler()
+            ->setContent(
+                $importFeed->getStoragePath() . "import-2023-02-02.csv",
+                'File contents 3'
+            );
+
+        $items = $importFeed->getImportFiles()->items;
+        $this->assertEquals(2, count($items));
+        $this->assertSame('assets/_imports/import-2023-01-01.csv', $items[0]->link);
+        $this->assertSame('assets/_imports/import-2023-02-02.csv', $items[1]->link);
+
+        $importFeed->getAssetHandler()->removeContent($importFeed->getStoragePath());
+    }
 }


### PR DESCRIPTION
### Description
- Plugins classes were removed from `league/flysystem` version 2 without any replacement([see docs](https://flysystem.thephpleague.com/docs/upgrade-from-1.x/)). 
- `getImportFiles ` method was updated to support new  changes in `league/flysystem` [see docs](https://flysystem.thephpleague.com/docs/upgrade-from-1.x/)

### Parent issue
- https://github.com/silverstripeltd/product-issues/issues/676

### Fix issue
- https://github.com/silverstripe/silverstripe-registry/actions/runs/4130270901/jobs/7159269470

