### PR TITLE
MNT Allow any order of returned files

### DIFF
--- a/tests/RegistryImportFeedTest.php
+++ b/tests/RegistryImportFeedTest.php
@@ -38,8 +38,9 @@ class RegistryImportFeedTest extends SapphireTest
 
         $items = $importFeed->getImportFiles()->items;
         $this->assertEquals(2, count($items));
-        $this->assertSame('assets/_imports/import-2023-01-01.csv', $items[0]->link);
-        $this->assertSame('assets/_imports/import-2023-02-02.csv', $items[1]->link);
+        $itemLinks = array_map(fn($item) => $item->link, $items);
+        $this->assertContains('assets/_imports/import-2023-01-01.csv', $itemLinks);
+        $this->assertContains('assets/_imports/import-2023-02-02.csv', $itemLinks);
 
         $importFeed->getAssetHandler()->removeContent($importFeed->getStoragePath());
     }


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/5

Fix for https://github.com/silverstripe/silverstripe-registry/actions/runs/4359379376/jobs/7621127559 - this tests passes locally, though for whatever reason the order of the files returned isn't always consistent in CI, so just allow it to return in any order