### PR TITLE
 FIX RegistryAdmin add missing return to import

### DIFF
--- a/src/RegistryAdmin.php
+++ b/src/RegistryAdmin.php
@@ -123,6 +123,6 @@ class RegistryAdmin extends ModelAdmin
         }
 
         $form->sessionMessage($message, 'good');
-        $this->redirectBack();
+        return $this->redirectBack();
     }
 }


### PR DESCRIPTION
## Description
When importing a CSV file into a registry it will **complete** the import but fails to return (redirect) back to the registry popup dialog with a **"good"** (successful) message. The user's gets a broken screen (css not loading). 

**Debugging error logs**
[Emergency] Uncaught TypeError: SilverStripe\Registry\RegistryAdmin::import(): **Return value must be of type SilverStripe\Control\HTTPResponse, none returned**

There is a missing **RETURN** in file RegistryAdmin > import function > line 126.
https://github.com/silverstripe/silverstripe-registry/blob/92c1a529a4da337f54d93191768aabb2d6217f28/src/RegistryAdmin.php#L126

I've added the return and tested that it works.

## Manual testing steps
1. Go to an existing Registry and export a CSV file 
2. Ensure the file meets the required import form fields requirements
3. Import the CSV file and it will produce an error

## Issues
 https://github.com/silverstripe/silverstripe-registry/issues/113

## Pull request checklist
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
