### PR TITLE
API Deprecate API that's changing in CMS 6

### DIFF
--- a/src/RegistryPage.php
+++ b/src/RegistryPage.php
@@ -25,6 +25,9 @@ class RegistryPage extends Page
 
     private static $table_name = 'RegistryPage';
 
+    /**
+     * @deprecated 5.4.0 Will be renamed to cms_icon_class
+     */
     private static $icon_class = 'font-icon-p-data';
 
     private static $db = [


### PR DESCRIPTION
Note that while this recipe won't be supported in CMS 6, the API is changing in superclasses which live in modules that WILL be supported, which means this API will change regardless.

## Issue
- https://github.com/silverstripe/silverstripe-cms/issues/2947